### PR TITLE
Full control over SaveChanges

### DIFF
--- a/src/System.Data.Entity.Hooks/DbHookContext.cs
+++ b/src/System.Data.Entity.Hooks/DbHookContext.cs
@@ -128,7 +128,13 @@ namespace System.Data.Entity.Hooks
 
             try
             {
-                return base.SaveChanges();
+                BeforeSaveChanges();
+
+                var rowsAffected = base.SaveChanges();
+
+                AfterSaveChanges(rowsAffected);
+
+                return rowsAffected;
             }
             finally
             {
@@ -167,6 +173,21 @@ namespace System.Data.Entity.Hooks
         protected void RegisterPostSaveHook(IDbHook dbHook)
         {
             _postSaveHooks.Add(dbHook);
+        }
+
+        /// <summary>
+        /// Called right before SaveChanges method of the DbContext is called, and after pre save hooks are executed.
+        /// </summary>
+        protected virtual void BeforeSaveChanges()
+        {
+        }
+
+        /// <summary>
+        /// Called right after SaveChanges method of the DbContext is called, and before post save hooks are executed.
+        /// </summary>
+        /// <param name="rowsAffected">The number of objects written to the underlying database.</param>
+        protected virtual void AfterSaveChanges(int rowsAffected)
+        {
         }
 
         private void ObjectMaterialized(object sender, ObjectMaterializedEventArgs e)


### PR DESCRIPTION
This way the inheritors have full control over before and after the call to the SaveChanges of the DbContext happens.I had an issue where i needed to implement audit and i wanted the audit to happen after all the pre save hooks are executed.And there was no way to do it except implementing IDbHookRegistrar myself and coping all the functionality of the DbHookContext.
